### PR TITLE
Optimize MegaAesCtrStream to reduce CPU usage by calling less often into OS socket API

### DIFF
--- a/MegaApiClient/MegaApiClient.cs
+++ b/MegaApiClient/MegaApiClient.cs
@@ -534,7 +534,7 @@
 
       Stream dataStream = this.webClient.GetRequestRaw(new Uri(downloadResponse.Url));
 
-      Stream resultStream = new MegaAesCtrStreamDecrypter(dataStream, downloadResponse.Size, nodeCrypto.Key, nodeCrypto.Iv, nodeCrypto.MetaMac);
+      Stream resultStream = new MegaAesCtrStreamDecrypter(new BufferedStream(dataStream), downloadResponse.Size, nodeCrypto.Key, nodeCrypto.Iv, nodeCrypto.MetaMac);
 #if !NET35
       if (cancellationToken.HasValue)
       {
@@ -576,7 +576,7 @@
 
       Stream dataStream = this.webClient.GetRequestRaw(new Uri(downloadResponse.Url));
 
-      Stream resultStream = new MegaAesCtrStreamDecrypter(dataStream, downloadResponse.Size, key, iv, metaMac);
+      Stream resultStream = new MegaAesCtrStreamDecrypter(new BufferedStream(dataStream), downloadResponse.Size, key, iv, metaMac);
 #if !NET35
       if (cancellationToken.HasValue)
       {


### PR DESCRIPTION
While using Duplicati to download files from Mega I noticed that a lot of CPU is spent repeatedly calling `Socket.Read` with 16 byte chunks. This is very CPU intensive.

![image](https://user-images.githubusercontent.com/12032350/48304773-aa608800-e51f-11e8-9347-43854f584e0d.png)

The best fix would be to read less often in bigger chunks. I opted for a simpler fix, though, which is to just interpose a `BufferedStream`. It will still be expensive to call into this stream with 16 byte requests but it will be far faster than actually calling into the OS kernel.

The other hotspot in this code (according to me repeatedly querying stacks as a primitive form of profiling) is the encryption code. Likely, this is very inefficient as well because of the 16 byte chunking. Fixing that would unleash a lot of throughput but it is beyond my abilities.

Duplicati currently uses 100% of one CPU core and delivers maybe 4MB/s of data. Normally, encryption happens at hundreds of megabytes per second. It would be awesome if one of the experienced project members had a better fix than my simple hack (feel free to discard this pull request in that case).
