### PR TITLE
Make progress reporting optional

### DIFF
--- a/MegaApiClient/Stream/ProgressionStream.cs
+++ b/MegaApiClient/Stream/ProgressionStream.cs
@@ -39,7 +39,7 @@ namespace CG.Web.MegaApiClient
       // Report 100% progress only if it was not already sent
       if (this.chunkSize != 0)
       {
-        this.progress.Report(100);
+        this.progress?.Report(100);
       }
     }
 
@@ -82,7 +82,7 @@ namespace CG.Web.MegaApiClient
       if (this.chunkSize >= this.reportProgressChunkSize)
       {
         this.chunkSize = 0;
-        this.progress.Report(this.Position / (double)this.Length * 100);
+        this.progress?.Report(this.Position / (double)this.Length * 100);
       }
     }
   }


### PR DESCRIPTION
Right now you have to always create either a delegate, or a local function, or some other doodad if you're using async Download methods, even if you do not care about reporting the progress.

Right now there's absolutely no validation if you pass `null` for the progress handler. I propose to simply ignore it in this case.