### PR TITLE
Introduced fix to 'undecrypted file' nodes

### DIFF
--- a/MegaApiClient/Node.cs
+++ b/MegaApiClient/Node.cs
@@ -120,7 +120,7 @@
     public byte[] MetaMac { get; private set; }
 
     [JsonIgnore]
-    public bool Failed { get; private set; }
+    public bool EmptyKey { get; private set; }
 
     #endregion
 
@@ -146,15 +146,16 @@
 
       this.CreationDate = this.SerializedCreationDate.ToDateTime();
 
-      if (string.IsNullOrEmpty(this.SerializedKey))
-      {
-        Failed = true;
-
-        return;
-      }
-
       if (this.Type == NodeType.File || this.Type == NodeType.Directory)
       {
+        // Check if file is not yet decrypted
+        if (string.IsNullOrEmpty(this.SerializedKey))
+        {
+          this.EmptyKey = true;
+
+          return;
+        }
+
         // There are cases where the SerializedKey property contains multiple keys separated with /
         // This can occur when a folder is shared and the parent is shared too.
         // Both keys are working so we use the first one

--- a/MegaApiClient/Node.cs
+++ b/MegaApiClient/Node.cs
@@ -119,6 +119,9 @@
     [JsonIgnore]
     public byte[] MetaMac { get; private set; }
 
+    [JsonIgnore]
+    public bool Failed { get; private set; }
+
     #endregion
 
     #region Deserialization
@@ -142,6 +145,13 @@
       }
 
       this.CreationDate = this.SerializedCreationDate.ToDateTime();
+
+      if (string.IsNullOrEmpty(this.SerializedKey))
+      {
+        Failed = true;
+
+        return;
+      }
 
       if (this.Type == NodeType.File || this.Type == NodeType.Directory)
       {

--- a/MegaApiClient/Serialization/GetNodes.cs
+++ b/MegaApiClient/Serialization/GetNodes.cs
@@ -38,7 +38,7 @@
 
     public Node[] Nodes { get; private set; }
 
-    public Node[] Failed { get; private set; }
+    public Node[] UndecryptedNodes { get; private set; }
 
     [JsonProperty("f")]
     public JRaw NodesSerialized { get; private set; }
@@ -55,8 +55,8 @@
     {
       var tempNodes = JsonConvert.DeserializeObject<Node[]>(this.NodesSerialized.ToString(), new NodeConverter(this.masterKey, ref this.sharedKeys));
 
-      this.Failed = tempNodes.Where(x => x.Failed).ToArray();
-      this.Nodes = tempNodes.Where(x => !x.Failed).ToArray();
+      this.UndecryptedNodes = tempNodes.Where(x => x.EmptyKey).ToArray();
+      this.Nodes = tempNodes.Where(x => !x.EmptyKey).ToArray();
     }
   }
 }

--- a/MegaApiClient/Serialization/GetNodes.cs
+++ b/MegaApiClient/Serialization/GetNodes.cs
@@ -1,6 +1,7 @@
 ﻿namespace CG.Web.MegaApiClient.Serialization
 {
   using System.Collections.Generic;
+  using System.Linq;
   using System.Runtime.Serialization;
   using Newtonsoft.Json;
   using Newtonsoft.Json.Linq;
@@ -37,6 +38,8 @@
 
     public Node[] Nodes { get; private set; }
 
+    public Node[] Failed { get; private set; }
+
     [JsonProperty("f")]
     public JRaw NodesSerialized { get; private set; }
 
@@ -50,7 +53,10 @@
     [OnDeserialized]
     public void OnDeserialized(StreamingContext ctx)
     {
-      this.Nodes = JsonConvert.DeserializeObject<Node[]>(this.NodesSerialized.ToString(), new NodeConverter(this.masterKey, ref this.sharedKeys));
+      var tempNodes = JsonConvert.DeserializeObject<Node[]>(this.NodesSerialized.ToString(), new NodeConverter(this.masterKey, ref this.sharedKeys));
+
+      this.Failed = tempNodes.Where(x => x.Failed).ToArray();
+      this.Nodes = tempNodes.Where(x => !x.Failed).ToArray();
     }
   }
 }


### PR DESCRIPTION
Hi,

So occasionally, there are some files that are still encrypted and look like this on Mega: 
![Untitled](https://user-images.githubusercontent.com/28737671/73305647-88b4f480-41e8-11ea-8fd8-1e647a414815.png)

This results in the `SerializedKey` being an empty string. As you know, `SerializedKey` corresponds to the 'k' value in the JSON that is parsed for the Node. An example of this is shown in here:

```    
{
      "h": "gYk0ya5z",
      "p": "pV8gXCJG",
      "u": "GjFNhnjfq4F",
      "t": 0,
      "a": "5RztPE7QHBOkdN11NctXNfQuOJBdwg2fqlIzYGlxNZ-jXPdEHQebIvvz-gvp0DeEV3cEHs70rs2kWCUVn1wmXRNsu09RWOyuaJl4IV_4fnz",
      "k": "",
      "s": 13502091,
      "fa": "887:0*xU5A4rZpVk0/885:1*FmGYhTlhZWU/580:8*-1kdUYxWeIQ",
      "ts": 1570655878
},
```

This causes the exception `Source array was not long enough. Check srcIndex and length, and the array's lower bounds.` to be thrown in `Crypto.GetPartsFromDecryptedKey(this.FullKey, out iv, out metaMac, out fileKey);` due to `FullKey` being empty. Now this is problematic since it stops the entirety of the rest of the nodes from being checked.

My solution is to check if `SerializedKey` is empty and if it is, to introduce a `Failed` boolean which indicates the node is not decryptable.

If this is not an ideal solution I'd be happy to change it.