### PR TITLE
#147 Use SendAsync instead PostAsync to retrieve headers and detect server errors

### DIFF
--- a/MegaApiClient.Tests/Context/TestContext.cs
+++ b/MegaApiClient.Tests/Context/TestContext.cs
@@ -66,7 +66,7 @@ namespace CG.Web.MegaApiClient.Tests.Context
     protected virtual IMegaApiClient CreateClient()
     {
       this.Options = new Options(applicationKey: "ewZQFBBC");
-      this.WebClient = new TestWebClient(new WebClient(this.WebTimeout, null, new TestMessageHandler(this.logMessageAction), true), MaxRetry, this.logMessageAction);
+      this.WebClient = new TestWebClient(new WebClient(this.WebTimeout, null, new TestMessageHandler(this.logMessageAction), false), MaxRetry, this.logMessageAction);
 
       return new MegaApiClient(this.Options, this.WebClient);
     }


### PR DESCRIPTION
In some situation, the mega servers return a 500 HTTP code (server busy) and this kind of response was not properly handled.