### PR TITLE
Use Aes.Create for NetStandard 2.0

### DIFF
--- a/MegaApiClient/Cryptography/Crypto.cs
+++ b/MegaApiClient/Cryptography/Crypto.cs
@@ -16,7 +16,7 @@
 
     static Crypto()
     {
-#if NETSTANDARD1_3
+#if NETSTANDARD1_3 || NETSTANDARD2_0
       AesCbc = Aes.Create(); // More per-call overhead but supported everywhere.
       IsKnownReusable = false;
 #else


### PR DESCRIPTION
Workaround for encryption/decryption issues with Xamarin projects.  See https://github.com/gpailler/MegaApiClient/issues/152