### PR TITLE
api calls hanging

### DIFF
--- a/MegaApiClient.Tests/Context/TestContext.cs
+++ b/MegaApiClient.Tests/Context/TestContext.cs
@@ -2,9 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit.Abstractions;
 
 namespace CG.Web.MegaApiClient.Tests.Context
@@ -57,7 +54,7 @@ namespace CG.Web.MegaApiClient.Tests.Context
     protected virtual IMegaApiClient CreateClient()
     {
       Options = new Options(applicationKey: "ewZQFBBC");
-      WebClient = new TestWebClient(new WebClient(WebTimeout, null, new TestMessageHandler(), false), MaxRetry, _logMessageAction);
+      WebClient = new TestWebClient(new WebClient(WebTimeout, null, false), MaxRetry, _logMessageAction);
 
       return new MegaApiClient(Options, WebClient);
     }
@@ -82,14 +79,6 @@ namespace CG.Web.MegaApiClient.Tests.Context
     private void OnApiRequestFailed(object _, ApiRequestFailedEventArgs e)
     {
       _logMessageAction($"ApiRequestFailed: {e.ApiResult}, {e.ApiUrl}, {e.AttemptNum}, {e.RetryDelay}, {e.ResponseJson}, {e.Exception} {e.Exception?.Message}");
-    }
-
-    private class TestMessageHandler : HttpClientHandler
-    {
-      protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-      {
-        return await base.SendAsync(request, cancellationToken);
-      }
     }
   }
 }

--- a/MegaApiClient/MegaApiClient.csproj
+++ b/MegaApiClient/MegaApiClient.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;net46;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;net46;net47;net471;netstandard1.3;netstandard2.0</TargetFrameworks>
     <RootNamespace>CG.Web.MegaApiClient</RootNamespace>
     <SignAssembly>False</SignAssembly>
     <DocumentationFile>bin\docs\MegaApiClient.xml</DocumentationFile>
@@ -43,26 +43,26 @@
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net40' Or '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net46'">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) == 'false'">
     <Reference Include="System" />
     <Reference Include="System.Web" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net46'">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) == 'false' And $(TargetFramework) != 'net40'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) == 'true'">
     <PackageReference Include="System.Net.Http">
       <Version>4.3.4</Version>
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+  <ItemGroup Condition="$(TargetFramework) == 'netstandard1.3'">
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net40' Or '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net46'">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard')) == 'false'">
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>../key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/MegaApiClient/WebClient_HttpWebRequest.cs
+++ b/MegaApiClient/WebClient_HttpWebRequest.cs
@@ -17,6 +17,11 @@ namespace CG.Web.MegaApiClient
 
     public WebClient(int responseTimeout = DefaultResponseTimeout, string userAgent = null)
     {
+      if (!ServicePointManager.SecurityProtocol.HasFlag((SecurityProtocolType)3072))
+      {
+        throw new NotSupportedException("mega.nz API requires support for TLS v1.2 or higher. Check https://gpailler.github.io/MegaApiClient/#compatibility for additional information");
+      }
+
       BufferSize = Options.DefaultBufferSize;
       _responseTimeout = responseTimeout;
       _userAgent = userAgent ?? GenerateUserAgent();

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,13 +14,14 @@ Getting started with MegaApiClient
 
 #### Compatibility
 
-The library supports .NET 4.0, .NET 4.5, .NET 4.6 and [.NET Standard 1.3](https://docs.microsoft.com/en-us/dotnet/standard/net-standard). Here is the list of all supported implementations:
+The library is built for the following targets: .NET 4.0, .NET 4.5, .NET 4.6, .NET 4.7, .NET 4.7.1, .NET Standard 1.3 and .NET Standard 2.0.
+Here is the list of all supported implementations:
 
 | Implementation             | Version   |
 |----------------------------|-----------|
 | .NET Framework             | 4.0       |
 | .NET Framework             | >= 4.5    |
-| .NET Core                  | >= 1.0    |
+| .NET Core / .NET           | >= 1.0    |
 | Mono                       | >= 4.6    |
 | Xamarin.iOS                | >= 10.0   |
 | Xamarin.Mac                | >= 3.0    |
@@ -28,12 +29,13 @@ The library supports .NET 4.0, .NET 4.5, .NET 4.6 and [.NET Standard 1.3](https:
 | Universal Windows Platform | >= 10.0   |
 | Unity*                     | >= 2018.2 |
 
-⚠️ TLS 1.2 support should be configured explicitely when using .NET Framework <= 4.5 or  all the API calls to Mega will hang.
-- For .NET Framework 4.5, add `ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;`
+---
+⚠️ TLS 1.2 support should be enforced when using .NET Framework <= 4.7 or all the API calls to Mega will hang.
+- For .NET Framework from 4.5 to 4.7.0, add `ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;`
 - For .NET Framework 4, add `ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;` (.NET 4.5 should be installed on the machine).
+- Alternatively, you can add relevant switches in your app.config https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls  
 
 ---
-
 \* Need a link.xml file if IL2CPP is used:
 ```
 <linker>
@@ -44,7 +46,6 @@ The library supports .NET 4.0, .NET 4.5, .NET 4.6 and [.NET Standard 1.3](https:
     </assembly>
 </linker>
 ```
-
 ---
 
 MegaApiClient source is available on [GitHub](https://github.com/gpailler/MegaApiClient) and is released under [MIT](https://choosealicense.com/licenses/mit/) license.


### PR DESCRIPTION
#178 Fix API calls hangs by checking Tls12 support or enforce Tls12 depending of the target:
- net40 : check that (SecurityProtocolType)3072 is specified
- net45 : check that SecurityProtocolType.Tls12 is specified
- net46 : check that SecurityProtocolType.Tls12 is specified
- net47 (target added) : check that SecurityProtocolType.Tls12 or SecurityProtocolType.UseDefault is specified
- net471 (target added) : force usage of Tls12 in HttpClient ctor
- netstandard1.3 : force usage of Tls12 in HttpClient ctor
- netstandard2.0 : force usage of Tls12 in HttpClient ctor