### PR TITLE
Support compressed api response

### DIFF
--- a/MegaApiClient/WebClient_HttpClient.cs
+++ b/MegaApiClient/WebClient_HttpClient.cs
@@ -112,9 +112,9 @@ namespace CG.Web.MegaApiClient
     private static HttpClient CreateHttpClient(int timeout, ProductInfoHeaderValue userAgent)
     {
 #if NET471 || NETSTANDARD
-      var httpClient = new HttpClient(new HttpClientHandler { SslProtocols = SslProtocols.Tls12 }, true);
+      var httpClient = new HttpClient(new HttpClientHandler { SslProtocols = SslProtocols.Tls12, AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate }, true);
 #else
-      var httpClient = new HttpClient();
+      var httpClient = new HttpClient(new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate });
 #endif
 
       httpClient.Timeout = TimeSpan.FromMilliseconds(timeout);


### PR DESCRIPTION
Fixes #211, allowing to handle compressed responses from Mega API. 

I was unable to run some automated tests - I noticed that some of them are integrated externally with Mega API, needing some previous configuration. As I am unsure how it could deal with my personal Mega account or the whole setup, I am trusting in an automated build and test run before my PR be merged. I didn't find any other references to a HttpClientHandler, neither in tests nor in checking SslProtocols.

If you prefer coverage with an automated test, I can do it after checking the test's project structure to write it following the current code design. I don't think creating 1k+ registries would be viable for an automated test. Maybe the better approach would be using a HttpClientHandler mock to assert that it was created - and called Mega API - with AutomaticDecompression with the expected value. But thinking about how to write this test, maybe it would be necessary to change the HttpClient object creation (private and static method) and be viable to mock and assert it. I really think could be hard to refactor it just to test in this way, and checking HttpClient object creation with reflection would be... to much?

