### PR TITLE
AES-NI support and 5x faster Pbkdf2 function

### DIFF
--- a/MegaApiClient.Tests/MegaApiClient.Tests.csproj
+++ b/MegaApiClient.Tests/MegaApiClient.Tests.csproj
@@ -12,7 +12,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="7.0.12" />
     <PackageReference Include="Polly-Signed" Version="5.9.0" />
     <PackageReference Include="xRetry" Version="1.8.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/MegaApiClient/Cryptography/Crypto.cs
+++ b/MegaApiClient/Cryptography/Crypto.cs
@@ -19,7 +19,7 @@
       s_aesCbc = Aes.Create(); // More per-call overhead but supported everywhere.
       s_isKnownReusable = false;
 #else
-      s_aesCbc = new AesManaged();
+      s_aesCbc = new AesCryptoServiceProvider(); // aes-ni support
       s_isKnownReusable = true;
 #endif
 

--- a/MegaApiClient/MegaApiClient.csproj
+++ b/MegaApiClient/MegaApiClient.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;net46;net47;net471;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;net46;net461;net47;net471;net481;netstandard1.3;netstandard2.0;net60;net70</TargetFrameworks>
     <RootNamespace>CG.Web.MegaApiClient</RootNamespace>
     <SignAssembly>False</SignAssembly>
     <DocumentationFile>bin\docs\MegaApiClient.xml</DocumentationFile>
@@ -63,8 +63,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <Compile Include="..\GlobalAssemblyInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) != 'netstandard1.3' And $(TargetFramework) != 'net45' And $(TargetFramework) != 'net46' And $(TargetFramework) != 'net40'">
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="7.0.12" />
   </ItemGroup>
 
   <!-- Source Link -->


### PR DESCRIPTION
* The AesManaged version is software only; it will not e.g. make use of processor instructions such as AES-NI
* Old Medo.Security.Cryptography Pbkdf2 function like before works with NET40, NET45, NET46, NETSTANDARD1_3
* New Microsoft.AspNetCore.Cryptography.KeyDerivation Pbkdf2 works with all other versions

**_Also_**:
Add net461; net481; net60; net70
Update Newtonsoft to 13.0.3