### PR TITLE
RequestCore > fix 'Unable to cast object of type 'System.Int64' to type 'Newtonsoft.Json.Linq.JArray' error

### DIFF
--- a/MegaApiClient/MegaApiClient.cs
+++ b/MegaApiClient/MegaApiClient.cs
@@ -1115,6 +1115,7 @@
       var uri = GenerateUrl(request.QueryArguments);
       object jsonData = null;
       var attempt = 0;
+      var apiCode = ApiResultCode.Ok;
       while (_options.ComputeApiRequestRetryWaitDelay(++attempt, out var retryDelay))
       {
         var dataResult = _webClient.PostRequestJson(uri, dataRequest);
@@ -1124,7 +1125,7 @@
           || jsonData is long
           || jsonData is JArray array && array[0].Type == JTokenType.Integer)
         {
-          var apiCode = jsonData == null
+          apiCode = jsonData == null
             ? ApiResultCode.RequestFailedRetry
             : jsonData is long
               ? (ApiResultCode)Enum.ToObject(typeof(ApiResultCode), jsonData)
@@ -1148,6 +1149,11 @@
         }
 
         break;
+      }
+
+      if (apiCode != ApiResultCode.Ok)
+      {
+        throw new ApiException(apiCode);
       }
 
       var data = ((JArray)jsonData)[0].ToString();


### PR DESCRIPTION
Fixing:

```cs
System.InvalidCastException: Unable to cast object of type 'System.Int64' to type 'Newtonsoft.Json.Linq.JArray'
   at CG.Web.MegaApiClient.MegaApiClient.RequestCore[TResponse](RequestBase request, Byte[] key)
   at CG.Web.MegaApiClient.MegaApiClient.Request[TResponse](RequestBase request, Byte[] key)
   at CG.Web.MegaApiClient.MegaApiClient.GenerateAuthInfos(String email, String password, String mfaKey)
   at CG.Web.MegaApiClient.MegaApiClient.Login(String email, String password, String mfaKey)
   at CG.Web.MegaApiClient.MegaApiClient.<>c__DisplayClass62_0.<LoginAsync>b__0()
```

Github issue: https://github.com/gpailler/MegaApiClient/issues/235
Thanks.