### PR TITLE
Fix handling of public shares

### DIFF
--- a/MegaApiClient/MegaApiClient.cs
+++ b/MegaApiClient/MegaApiClient.cs
@@ -1112,7 +1112,7 @@
         where TResponse : class
     {
       var dataRequest = JsonConvert.SerializeObject(new object[] { request });
-      var uri = GenerateUrl(request.QueryArguments);
+      var uri = GenerateUrl(request.QueryArguments, request.UseSession);
       object jsonData = null;
       var attempt = 0;
       var apiCode = ApiResultCode.Ok;
@@ -1182,7 +1182,7 @@
 #endif
     }
 
-    private Uri GenerateUrl(Dictionary<string, string> queryArguments)
+    private Uri GenerateUrl(Dictionary<string, string> queryArguments, bool useSession = true)
     {
       var query = new Dictionary<string, string>(queryArguments)
       {
@@ -1190,7 +1190,7 @@
         ["ak"] = _options.ApplicationKey
       };
 
-      if (!string.IsNullOrEmpty(_sessionId))
+      if (useSession && !string.IsNullOrEmpty(_sessionId))
       {
         query["sid"] = _sessionId;
       }

--- a/MegaApiClient/Node.cs
+++ b/MegaApiClient/Node.cs
@@ -136,54 +136,72 @@
           return;
         }
 
-        // There are cases where the SerializedKey property contains multiple keys separated with /
-        // This can occur when a folder is shared and the parent is shared too.
-        // Both keys are working so we use the first one
-        var serializedKey = SerializedKey.Split('/')[0];
-        var splitPosition = serializedKey.IndexOf(":", StringComparison.Ordinal);
-        var encryptedKey = serializedKey.Substring(splitPosition + 1).FromBase64();
+        // The SerializedKey property can contain multiple keys separated with /
+        // This occurs when a folder is shared and the parent is shared too, or for
+        // shared folder links where the owner's key and share key are both present.
+        // Try each key and use the first one that produces valid attributes.
+        var serializedKeys = SerializedKey.Split('/');
 
-        // If node is shared, we need to retrieve shared masterkey
-        if (_sharedKeys != null)
+        foreach (var serializedKey in serializedKeys)
         {
-          var handle = serializedKey.Substring(0, splitPosition);
-          var sharedKey = _sharedKeys.FirstOrDefault(x => x.Id == handle);
-          if (sharedKey != null)
+          var splitPosition = serializedKey.IndexOf(":", StringComparison.Ordinal);
+          if (splitPosition < 0)
           {
-            _masterKey = Crypto.DecryptKey(sharedKey.Key.FromBase64(), _masterKey);
-            if (Type == NodeType.Directory)
+            continue;
+          }
+
+          var handle = serializedKey.Substring(0, splitPosition);
+          var encryptedKey = serializedKey.Substring(splitPosition + 1).FromBase64();
+
+          // If node is shared, we need to retrieve shared masterkey
+          var usedMasterKey = _masterKey;
+          byte[] sharedKeyValue = null;
+          if (_sharedKeys != null)
+          {
+            var sharedKey = _sharedKeys.FirstOrDefault(x => x.Id == handle);
+            if (sharedKey != null)
             {
-              SharedKey = _masterKey;
+              usedMasterKey = Crypto.DecryptKey(sharedKey.Key.FromBase64(), _masterKey);
+              sharedKeyValue = Type == NodeType.Directory
+                ? usedMasterKey
+                : Crypto.DecryptKey(encryptedKey, usedMasterKey);
             }
-            else
-            {
-              SharedKey = Crypto.DecryptKey(encryptedKey, _masterKey);
-            }
+          }
+
+          if (encryptedKey.Length != 16 && encryptedKey.Length != 32)
+          {
+            continue;
+          }
+
+          var fullKey = Crypto.DecryptKey(encryptedKey, usedMasterKey);
+          byte[] nodeKey;
+          byte[] iv = null;
+          byte[] metaMac = null;
+
+          if (Type == NodeType.File)
+          {
+            Crypto.GetPartsFromDecryptedKey(fullKey, out iv, out metaMac, out nodeKey);
+          }
+          else
+          {
+            nodeKey = fullKey;
+          }
+
+          var attrs = Crypto.DecryptAttributes(SerializedAttributes.FromBase64(), nodeKey);
+
+          FullKey = fullKey;
+          Key = nodeKey;
+          Iv = iv;
+          MetaMac = metaMac;
+          SharedKey = sharedKeyValue;
+          Attributes = attrs;
+
+          if (attrs?.Name != null && !attrs.Name.StartsWith("Attribute deserialization failed"))
+          {
+            break;
           }
         }
 
-        if (encryptedKey.Length != 16 && encryptedKey.Length != 32)
-        {
-          // Invalid key size
-          return;
-        }
-
-        FullKey = Crypto.DecryptKey(encryptedKey, _masterKey);
-
-        if (Type == NodeType.File)
-        {
-          Crypto.GetPartsFromDecryptedKey(FullKey, out var iv, out var metaMac, out var fileKey);
-
-          Iv = iv;
-          MetaMac = metaMac;
-          Key = fileKey;
-        }
-        else
-        {
-          Key = FullKey;
-        }
-
-        Attributes = Crypto.DecryptAttributes(SerializedAttributes.FromBase64(), Key);
         FileAttributes = DeserializeFileAttributes(SerializedFileAttributes);
       }
     }
@@ -278,12 +296,12 @@
         {
           return true;
         }
-        else
+
+        return _node.SerializedKey.Split('/').Any(key =>
         {
-          var serializedKey = _node.SerializedKey.Split('/')[0];
-          var splitPosition = serializedKey.IndexOf(":", StringComparison.Ordinal);
-          return serializedKey.Substring(0, splitPosition) == Id;
-        }
+          var splitPosition = key.IndexOf(":", StringComparison.Ordinal);
+          return splitPosition >= 0 && key.Substring(0, splitPosition) == Id;
+        });
       }
     }
   }

--- a/MegaApiClient/Serialization/DownloadUrl.cs
+++ b/MegaApiClient/Serialization/DownloadUrl.cs
@@ -12,6 +12,7 @@
       if (node is PublicNode publicNode)
       {
         QueryArguments["n"] = publicNode.ShareId;
+        UseSession = false;
       }
     }
 

--- a/MegaApiClient/Serialization/GetNodes.cs
+++ b/MegaApiClient/Serialization/GetNodes.cs
@@ -12,6 +12,8 @@
       : base("f")
     {
       C = 1;
+      Ca = 1;
+      UseSession = false;
 
       if (shareId != null)
       {
@@ -27,6 +29,9 @@
 
     [JsonProperty("r")]
     public int R { get; private set; }
+
+    [JsonProperty("ca")]
+    public int Ca { get; private set; }
   }
 
   internal class GetNodesResponse

--- a/MegaApiClient/Serialization/RequestBase.cs
+++ b/MegaApiClient/Serialization/RequestBase.cs
@@ -9,6 +9,7 @@
     {
       Action = action;
       QueryArguments = new Dictionary<string, string>();
+      UseSession = true;
     }
 
     [JsonProperty("a")]
@@ -16,5 +17,8 @@
 
     [JsonIgnore]
     public Dictionary<string, string> QueryArguments { get; }
+
+    [JsonIgnore]
+    public bool UseSession { get; protected set; }
   }
 }


### PR DESCRIPTION
This fixes #240 (at least for my use case of downloading public shares)

Fix attribute decryption for nodes with multiple keys and correctly detect share root.

Also, don't send authenticated sid for folder-share node listings or download URL requests for public links; authenticated requests caused Mega API to return ResourceAdministrativelyBlocked (-16)